### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,6 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  # Autoformat: YAML, JSON, Markdown, etc.
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
@@ -58,23 +57,11 @@ repos:
         args:
           ['--no-error-on-unmatched-pattern', '--ignore-unknown']
 
-  # Lint: Markdown
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:
       - id: markdownlint
         args: ["--fix"]
-
-  # - repo: https://github.com/psf/black-pre-commit-mirror
-  #   rev: 24.4.2
-  #   hooks:
-  #     - id: black
-  #     - id: black-jupyter
-
-  # - repo: https://github.com/tomcatling/black-nb
-  #   rev: '0.7'
-  #   hooks:
-  #     - id: black-nb
 
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1
@@ -97,12 +84,6 @@ repos:
     hooks:
       - id: pydocstyle
         additional_dependencies: ["tomli"]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
 
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
     rev: v1.7.0.14


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit